### PR TITLE
Fix ChallengeResponse result decoding.

### DIFF
--- a/backend/pkg/veraison/veraison.go
+++ b/backend/pkg/veraison/veraison.go
@@ -14,6 +14,7 @@
 package veraison
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -79,12 +80,17 @@ func SendEvidenceAndSignature(cfg *verification.ChallengeResponseConfig, session
 
 	// extract golden values from body
 	fmt.Printf("\n%x\n", data)
-	attestationResultJSON, err := cfg.ChallengeResponse(data, TPMEvidenceMediaType, sessionId)
+	attestationResultRawMessage, err := cfg.ChallengeResponse(data, TPMEvidenceMediaType, sessionId)
 	if err != nil {
 		return nil, fmt.Errorf("challenge-response session failed: %v", err)
 	}
 
-	return attestationResultJSON, nil
+	var attestationResultJWT string
+	if err = json.Unmarshal(attestationResultRawMessage, &attestationResultJWT); err != nil {
+		return nil, fmt.Errorf("challenge-response result decoding failed: %v", err)
+	}
+
+	return []byte(attestationResultJWT), nil
 }
 
 // This does POST /submit, Body: { CoRIM }`


### PR DESCRIPTION
ChallengeResponse() returns a json.RawMessage, which means that there is an extra level of unmarshalling necessary to get a byte sequence that can be decoded as JWT.

The RawMessage contains a JSON-encoded string. Effectively, it contains an additional set of double quotes enclosing the actual string. This cases a problem when trying to decode it as JWT, as that assumes a string which a base64 encoding of JSON (the double quote is not a valid base64 character).